### PR TITLE
Bug fix for reusing cells after swiping one away

### DIFF
--- a/VerticalCardSwiper/View/CardCell.swift
+++ b/VerticalCardSwiper/View/CardCell.swift
@@ -116,4 +116,13 @@ class CardCell: UICollectionViewCell {
         })
         delegate?.didSwipeAway(cell: self) 
     }
+    
+    /**
+     Prepares for reuse by resetting the anchorPoint back to the default value. This is necessary because in HomeVC we are manipulating the anchorPoint during dragging animation.
+    */
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        // reset to default value (https://developer.apple.com/documentation/quartzcore/calayer/1410817-anchorpoint)
+        self.layer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+    }
 }


### PR DESCRIPTION
Manipulating the anchorPoint of the layer during panning results in messed up layout - we need to reset it after in prepareForReuse to make it work properly