### PR TITLE
Fixed bug where receded cells would be counted in indexPathsForVisibleItems

### DIFF
--- a/Sources/CardCell.swift
+++ b/Sources/CardCell.swift
@@ -32,6 +32,8 @@ import UIKit
     
     internal weak var delegate: CardDelegate?
     
+    var isReceeded: Bool = false
+    
     open override func layoutSubviews() {
         
         self.layer.shouldRasterize = true
@@ -43,9 +45,11 @@ import UIKit
     open override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
         super.apply(layoutAttributes)
         
+        isReceeded = (layoutAttributes.zIndex == 0)
+        
         self.layer.zPosition = CGFloat(layoutAttributes.zIndex)
     }
-
+    
     open override func prepareForReuse() {
         super.prepareForReuse()
         
@@ -61,6 +65,8 @@ import UIKit
         
         delegate?.didDragCard(cell: self, swipeDirection: determineCardSwipeDirection())
         
+        print("animateCard")
+        
         var transform = CATransform3DIdentity
         transform = CATransform3DRotate(transform, angle, 0, 0, 1)
         transform = CATransform3DTranslate(transform, horizontalTranslation, 0, 1)
@@ -72,6 +78,8 @@ import UIKit
      Resets the CardCell back to the center of the VerticalCardSwiperView.
      */
     public func resetToCenterPosition(){
+        
+        print("resetToCenterPosition")
         
         let cardCenterX = self.frame.midX
         let centerX = self.bounds.midX
@@ -96,6 +104,8 @@ import UIKit
      */
     internal func endedPanAnimation(angle: CGFloat){
         
+        print("endedpanAnimation")
+        
         let swipePercentageMargin = self.bounds.width * 0.4
         let cardCenterX = self.frame.midX
         let centerX = self.bounds.midX
@@ -113,6 +123,8 @@ import UIKit
      - parameter angle: The angle that the card will rotate in (depends on direction). Positive means the card is swiped to the right, a negative angle means the card is swiped to the left.
      */
     fileprivate func animateOffScreen(angle: CGFloat){
+        
+        print("animateOffScreen")
         
         var transform = CATransform3DIdentity
         let direction = determineCardSwipeDirection()
@@ -146,6 +158,8 @@ import UIKit
     }
     
     fileprivate func determineCardSwipeDirection() -> SwipeDirection {
+        
+        print("determineCardsWIPEdiRECTION")
         
         let cardCenterX = self.frame.midX
         let centerX = self.bounds.midX

--- a/Sources/CardCell.swift
+++ b/Sources/CardCell.swift
@@ -32,7 +32,7 @@ import UIKit
     
     internal weak var delegate: CardDelegate?
     
-    var isReceeded: Bool = false
+    public var isReceeded: Bool = false
     
     open override func layoutSubviews() {
         
@@ -65,8 +65,6 @@ import UIKit
         
         delegate?.didDragCard(cell: self, swipeDirection: determineCardSwipeDirection())
         
-        print("animateCard")
-        
         var transform = CATransform3DIdentity
         transform = CATransform3DRotate(transform, angle, 0, 0, 1)
         transform = CATransform3DTranslate(transform, horizontalTranslation, 0, 1)
@@ -78,8 +76,6 @@ import UIKit
      Resets the CardCell back to the center of the VerticalCardSwiperView.
      */
     public func resetToCenterPosition(){
-        
-        print("resetToCenterPosition")
         
         let cardCenterX = self.frame.midX
         let centerX = self.bounds.midX
@@ -104,8 +100,6 @@ import UIKit
      */
     internal func endedPanAnimation(angle: CGFloat){
         
-        print("endedpanAnimation")
-        
         let swipePercentageMargin = self.bounds.width * 0.4
         let cardCenterX = self.frame.midX
         let centerX = self.bounds.midX
@@ -123,8 +117,6 @@ import UIKit
      - parameter angle: The angle that the card will rotate in (depends on direction). Positive means the card is swiped to the right, a negative angle means the card is swiped to the left.
      */
     fileprivate func animateOffScreen(angle: CGFloat){
-        
-        print("animateOffScreen")
         
         var transform = CATransform3DIdentity
         let direction = determineCardSwipeDirection()
@@ -158,8 +150,6 @@ import UIKit
     }
     
     fileprivate func determineCardSwipeDirection() -> SwipeDirection {
-        
-        print("determineCardsWIPEdiRECTION")
         
         let cardCenterX = self.frame.midX
         let centerX = self.bounds.midX

--- a/Sources/CardCell.swift
+++ b/Sources/CardCell.swift
@@ -32,8 +32,6 @@ import UIKit
     
     internal weak var delegate: CardDelegate?
     
-    public var isReceeded: Bool = false
-    
     open override func layoutSubviews() {
         
         self.layer.shouldRasterize = true
@@ -44,8 +42,6 @@ import UIKit
     
     open override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
         super.apply(layoutAttributes)
-        
-        isReceeded = (layoutAttributes.zIndex == 0)
         
         self.layer.zPosition = CGFloat(layoutAttributes.zIndex)
     }

--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -31,11 +31,11 @@ internal extension UIPanGestureRecognizer {
         let velocity = self.velocity(in: view)
         let vertical = abs(velocity.y) > abs(velocity.x)
         switch (vertical, velocity.x, velocity.y) {
-        case (true, _, let y) where y < 0: return .Up
-        case (true, _, let y) where y > 0: return .Down
-        case (false, let x, _) where x > 0: return .Right
-        case (false, let x, _) where x < 0: return .Left
-        default: return PanDirection.None
+            case (true, _, let y) where y < 0: return .Up
+            case (true, _, let y) where y > 0: return .Down
+            case (false, let x, _) where x > 0: return .Right
+            case (false, let x, _) where x < 0: return .Left
+            default: return .None
         }
     }
 }

--- a/Sources/VerticalCardSwiper.swift
+++ b/Sources/VerticalCardSwiper.swift
@@ -213,7 +213,7 @@ extension VerticalCardSwiper: UIGestureRecognizerDelegate {
     
     @objc fileprivate func handleTap(sender: UITapGestureRecognizer) {
         if let delegate = delegate {
-            if let wasTapped = delegate.wasTapped {
+            if let wasTapped = delegate.didTapCard {
                 /// The taplocation relative to the collectionView.
                 let locationInCollectionView = sender.location(in: verticalCardSwiperView)
                 
@@ -226,7 +226,7 @@ extension VerticalCardSwiper: UIGestureRecognizerDelegate {
     
     @objc fileprivate func handleHold(sender: UILongPressGestureRecognizer) {
         if let delegate = delegate {
-            if let wasHeld = delegate.wasHeld {
+            if let wasHeld = delegate.didHoldCard {
                 /// The taplocation relative to the collectionView.
                 let locationInCollectionView = sender.location(in: verticalCardSwiperView)
                 

--- a/Sources/VerticalCardSwiper.swift
+++ b/Sources/VerticalCardSwiper.swift
@@ -213,18 +213,12 @@ extension VerticalCardSwiper: UIGestureRecognizerDelegate {
     
     @objc fileprivate func handleTap(sender: UITapGestureRecognizer) {
         if let delegate = delegate {
-            if let wasTapped = delegate.didTapCard {
-                /// The taplocation relative to the superview.
-                let location = sender.location(in: self)
+            if let wasTapped = delegate.wasTapped {
                 /// The taplocation relative to the collectionView.
                 let locationInCollectionView = sender.location(in: verticalCardSwiperView)
                 
-                if swipeAbleArea != nil {
-                    if swipeAbleArea.contains(location) && !verticalCardSwiperView.isScrolling {
-                        if let tappedCardIndex = verticalCardSwiperView.indexPathForItem(at: locationInCollectionView) {
-                            wasTapped(verticalCardSwiperView, tappedCardIndex.row)
-                        }
-                    }
+                if let tappedCardIndex = verticalCardSwiperView.indexPathForItem(at: locationInCollectionView) {
+                    wasTapped(verticalCardSwiperView, tappedCardIndex.row)
                 }
             }
         }
@@ -232,16 +226,12 @@ extension VerticalCardSwiper: UIGestureRecognizerDelegate {
     
     @objc fileprivate func handleHold(sender: UILongPressGestureRecognizer) {
         if let delegate = delegate {
-            if let wasHeld = delegate.didHoldCard {
-                /// The taplocation relative to the superview.
-                let location = sender.location(in: self)
+            if let wasHeld = delegate.wasHeld {
                 /// The taplocation relative to the collectionView.
                 let locationInCollectionView = sender.location(in: verticalCardSwiperView)
                 
-                if swipeAbleArea.contains(location) && !verticalCardSwiperView.isScrolling {
-                    if let swipedCardIndex = verticalCardSwiperView.indexPathForItem(at: locationInCollectionView) {
-                        wasHeld(verticalCardSwiperView, swipedCardIndex.row, sender.state)
-                    }
+                if let swipedCardIndex = verticalCardSwiperView.indexPathForItem(at: locationInCollectionView) {
+                    wasHeld(verticalCardSwiperView, swipedCardIndex.row, sender.state)
                 }
             }
         }

--- a/Sources/VerticalCardSwiperView.swift
+++ b/Sources/VerticalCardSwiperView.swift
@@ -34,30 +34,29 @@ public class VerticalCardSwiperView: UICollectionView {
         return (self.isDragging || self.isTracking || self.isDecelerating)
     }
     
-    public var indexesForVisibleCards: [IndexPath] {
-        var paths: [IndexPath] = []
+    /**
+     Returns an array of indexes (as Int) that are currently visible in the `VerticalCardSwiperView`.
+     This does not include cards that are behind the card that is in focus.
+     - returns: An array of indexes (as Int) that are currently visible.
+     */
+    public var indexesForVisibleCards: [Int] {
         
+        let lowestIndex = self.indexPathsForVisibleItems.min()?.row ?? 0
+        
+        // when first card is focussed, return as usual.
+        if (visibleCells.count == 2 && lowestIndex == 0) {
+            return self.indexPathsForVisibleItems.map({$0.row}).sorted()
+        }
+        
+        var indexes: [Int] = []
+        // Add each visible cell except the lowest one and return
         for cell in self.visibleCells {
-            if let cell = cell as? CardCell {
-                if let indexPath = self.indexPath(for: cell) {
-                    if(paths.count > indexPath.row) {
-                        paths.insert(indexPath, at: indexPath.row)
-                    } else {
-                        paths.append(indexPath)
-                    }
-                }
+            
+            if let index = self.indexPath(for: cell)?.row, index != lowestIndex {
+                indexes.append(index)
             }
         }
-        
-        if(paths.count == 3) {
-            paths.remove(at: 0)
-        } else if(paths.count == 2) {
-            if(paths[0].row > 0) {
-                paths.remove(at: 0)
-            }
-        }
-        
-        return paths
+        return indexes.sorted()
     }
     
     /**

--- a/Sources/VerticalCardSwiperView.swift
+++ b/Sources/VerticalCardSwiperView.swift
@@ -34,20 +34,30 @@ public class VerticalCardSwiperView: UICollectionView {
         return (self.isDragging || self.isTracking || self.isDecelerating)
     }
     
-    public override var indexPathsForVisibleItems: [IndexPath] {
+    public var indexesForVisibleCards: [IndexPath] {
         var paths: [IndexPath] = []
         
         for cell in self.visibleCells {
             if let cell = cell as? CardCell {
-                if(!cell.isReceeded) {
-                    if let indexPath = self.indexPath(for: cell) {
+                if let indexPath = self.indexPath(for: cell) {
+                    if(paths.count > indexPath.row) {
+                        paths.insert(indexPath, at: indexPath.row)
+                    } else {
                         paths.append(indexPath)
                     }
                 }
             }
         }
         
-        return paths.reversed()
+        if(paths.count == 3) {
+            paths.remove(at: 0)
+        } else if(paths.count == 2) {
+            if(paths[0].row > 0) {
+                paths.remove(at: 0)
+            }
+        }
+        
+        return paths
     }
     
     /**

--- a/Sources/VerticalCardSwiperView.swift
+++ b/Sources/VerticalCardSwiperView.swift
@@ -34,6 +34,22 @@ public class VerticalCardSwiperView: UICollectionView {
         return (self.isDragging || self.isTracking || self.isDecelerating)
     }
     
+    public override var indexPathsForVisibleItems: [IndexPath] {
+        var paths: [IndexPath] = []
+        
+        for cell in self.visibleCells {
+            if let cell = cell as? CardCell {
+                if(!cell.isReceeded) {
+                    if let indexPath = self.indexPath(for: cell) {
+                        paths.append(indexPath)
+                    }
+                }
+            }
+        }
+        
+        return paths.reversed()
+    }
+    
     /**
      Returns a reusable cell object located by its identifier.
      Call this method from your data source object when asked to provide a new cell for the VerticalCardSwiperView.
@@ -48,7 +64,7 @@ public class VerticalCardSwiperView: UICollectionView {
      - parameter identifier: The reuse identifier for the specified cell. This parameter must not be nil.
      
      - parameter index: The index specifying the location of the cell. The data source receives this information when it is asked for the cell and should just pass it along. This method uses the index to perform additional configuration based on the cell’s position in the VerticalCardSwiperView.
-    */
+     */
     public func dequeueReusableCell(withReuseIdentifier identifier: String, for index: Int) -> UICollectionViewCell {
         return self.dequeueReusableCell(withReuseIdentifier: identifier, for: IndexPath(row: index, section: 0))
     }

--- a/Sources/VerticalCardSwiperView.swift
+++ b/Sources/VerticalCardSwiperView.swift
@@ -50,10 +50,10 @@ public class VerticalCardSwiperView: UICollectionView {
         
         var indexes: [Int] = []
         // Add each visible cell except the lowest one and return
-        for cell in self.visibleCells {
-            
-            if let index = self.indexPath(for: cell)?.row, index != lowestIndex {
-                indexes.append(index)
+        
+        for cellIndexPath in self.indexPathsForVisibleItems {
+            if (cellIndexPath.row != lowestIndex) {
+                indexes.append(cellIndexPath.row)
             }
         }
         return indexes.sorted()


### PR DESCRIPTION
### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes an issue where unfocused cards would not be able to be tapped.

Solves an issue where hidden cards (see image) would be counted when `indexPathsForVisibleItems` is ran.

![img_7657](https://user-images.githubusercontent.com/8293444/48489231-7a183280-e81a-11e8-86f8-a89b0a9c3b7e.jpg)

### Description
`didTapCard` and `didHoldCard` no longer checks if the card tapped is the top card.

`indexPathsForVisibleItems` now returns an array where each cell is checked that it hasn't 'receded' (gone behind another card). If the cell has receded, it won't be added to the array.