### PR TITLE
added delegate function to detect when user scroll between cards ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,10 @@ class ViewController: UIViewController, VerticalCardSwiperDelegate {
     
         // Tells the delegate when the user scrolls through the cards (optional).
     }
-    func scrollDidEnded(verticalCardSwiperView: VerticalCardSwiperView) {
     
-    // Tells the delegate when the user scroll Ends through the cards (optional).
+    func didEndScroll(verticalCardSwiperView: VerticalCardSwiperView) {
+    
+        // Tells the delegate when scrolling through the cards came to an end.
     }
     
     func didDragCard(card: CardCell, index: Int, swipeDirection: SwipeDirection) {

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ class ViewController: UIViewController, VerticalCardSwiperDelegate {
     
         // Tells the delegate when the user scrolls through the cards (optional).
     }
+    func scrollDidEnded(verticalCardSwiperView: VerticalCardSwiperView) {
+    
+    // Tells the delegate when the user scroll Ends through the cards (optional).
+    }
     
     func didDragCard(card: CardCell, index: Int, swipeDirection: SwipeDirection) {
     

--- a/Sources/VerticalCardSwiper.swift
+++ b/Sources/VerticalCardSwiper.swift
@@ -356,7 +356,14 @@ extension VerticalCardSwiper: UICollectionViewDelegate, UICollectionViewDataSour
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         delegate?.didScroll?(verticalCardSwiperView: verticalCardSwiperView)
     }
-    
+    public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        if !decelerate{
+            delegate?.scrollDidEnded?(verticalCardSwiperView: verticalCardSwiperView)
+        }
+    }
+    public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+         delegate?.scrollDidEnded?(verticalCardSwiperView: verticalCardSwiperView)
+    }
     fileprivate func setupVerticalCardSwiperView(){
         
         verticalCardSwiperView = VerticalCardSwiperView(frame: self.frame, collectionViewLayout: flowLayout)

--- a/Sources/VerticalCardSwiper.swift
+++ b/Sources/VerticalCardSwiper.swift
@@ -356,14 +356,21 @@ extension VerticalCardSwiper: UICollectionViewDelegate, UICollectionViewDataSour
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         delegate?.didScroll?(verticalCardSwiperView: verticalCardSwiperView)
     }
+    
     public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        if !decelerate{
-            delegate?.scrollDidEnded?(verticalCardSwiperView: verticalCardSwiperView)
+        if !decelerate {
+            delegate?.didEndScroll?(verticalCardSwiperView: verticalCardSwiperView)
         }
     }
+    
     public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-         delegate?.scrollDidEnded?(verticalCardSwiperView: verticalCardSwiperView)
+        delegate?.didEndScroll?(verticalCardSwiperView: verticalCardSwiperView)
     }
+    
+    public func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        delegate?.didEndScroll?(verticalCardSwiperView: verticalCardSwiperView)
+    }
+    
     fileprivate func setupVerticalCardSwiperView(){
         
         verticalCardSwiperView = VerticalCardSwiperView(frame: self.frame, collectionViewLayout: flowLayout)

--- a/Sources/VerticalCardSwiperDelegate.swift
+++ b/Sources/VerticalCardSwiperDelegate.swift
@@ -71,6 +71,11 @@ import Foundation
      - parameter verticalCardSwiperView: The `VerticalCardSwiperView` that displays the cardcells.
      */
     @objc optional func didScroll(verticalCardSwiperView: VerticalCardSwiperView)
+    /**
+     Tells the delegate when user scroll through the cards end.
+      - parameter verticalCardSwiperView: The `VerticalCardSwiperView` that displays the cardcells.
+     */
+    @objc optional func scrollDidEnded(verticalCardSwiperView: VerticalCardSwiperView)
     
     /**
      Allows you to return the size as a CGSize for each card at their specified index.

--- a/Sources/VerticalCardSwiperDelegate.swift
+++ b/Sources/VerticalCardSwiperDelegate.swift
@@ -72,10 +72,10 @@ import Foundation
      */
     @objc optional func didScroll(verticalCardSwiperView: VerticalCardSwiperView)
     /**
-     Tells the delegate when user scroll through the cards end.
+     Tells the delegate when scrolling through the cards came to an end.
       - parameter verticalCardSwiperView: The `VerticalCardSwiperView` that displays the cardcells.
      */
-    @objc optional func scrollDidEnded(verticalCardSwiperView: VerticalCardSwiperView)
+    @objc optional func didEndScroll(verticalCardSwiperView: VerticalCardSwiperView)
     
     /**
      Allows you to return the size as a CGSize for each card at their specified index.


### PR DESCRIPTION
<!-- Thanks for contributing to _VerticalCardSwiper_. Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
in my case i need to know when scrolling between cards will end so i added another delegate function to detect and tell this
### Description
I added another function to VerticalCardSwiperDelegate so developer can find out when user scrolls between calls is ended.
it is fired from scrollview delegate methods