### PR TITLE
Fix crash in scrollToCard when it is called before the view layout is properly set up

### DIFF
--- a/Sources/VerticalCardSwiper.swift
+++ b/Sources/VerticalCardSwiper.swift
@@ -365,19 +365,22 @@ extension VerticalCardSwiper: UICollectionViewDelegate, UICollectionViewDataSour
      instead of functions like `viewDidLoad` as the underlying collectionView needs to be loaded first for this to work.
      - parameter index: The index of the item to scroll into view.
      - parameter animated: Specify true to animate the scrolling behavior or false to adjust the scroll view’s visible content immediately.
+     - Returns: True if scrolling succeeds. False if scrolling failed because the view layout has not been established yet.
      */
-    public func scrollToCard(at index: Int, animated: Bool) {
+    public func scrollToCard(at index: Int, animated: Bool) -> Bool {
 
         /**
          scrollToItem & scrollRectToVisible were giving issues with reliable scrolling,
          so we're using setContentOffset for the time being.
          See: https://github.com/JoniVR/VerticalCardSwiper/issues/23
          */
-        guard index >= 0 && index < verticalCardSwiperView.numberOfItems(inSection: 0) else { return }
+        guard index >= 0, index < verticalCardSwiperView.numberOfItems(inSection: 0), let cellHeight = flowLayout.cellHeight else { return false }
 
-        let y = CGFloat(index) * (flowLayout.cellHeight + flowLayout.minimumLineSpacing) - topInset
+        let y = CGFloat(index) * (cellHeight + flowLayout.minimumLineSpacing) - topInset
         let point = CGPoint(x: verticalCardSwiperView.contentOffset.x, y: y)
         verticalCardSwiperView.setContentOffset(point, animated: animated)
+        
+        return true
     }
 
     /**

--- a/Sources/VerticalCardSwiperFlowLayout.swift
+++ b/Sources/VerticalCardSwiperFlowLayout.swift
@@ -30,7 +30,7 @@ internal class VerticalCardSwiperFlowLayout: UICollectionViewFlowLayout {
     /// This property enables paging per card. Default is true.
     internal var isPagingEnabled: Bool = true
     /// Stores the height of a CardCell.
-    internal var cellHeight: CGFloat!
+    internal var cellHeight: CGFloat?
     /// Allows you to make the previous card visible or not visible (stack effect). Default is `true`.
     internal var isPreviousCardVisible: Bool = true
 
@@ -83,7 +83,7 @@ internal class VerticalCardSwiperFlowLayout: UICollectionViewFlowLayout {
     internal override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint, withScrollingVelocity velocity: CGPoint) -> CGPoint {
 
         // If the property `isPagingEnabled` is set to false, we don't enable paging and thus return the current contentoffset.
-        guard let collectionView = self.collectionView, isPagingEnabled else {
+        guard let collectionView = self.collectionView, let cellHeight = cellHeight, isPagingEnabled else {
             let latestOffset = super.targetContentOffset(forProposedContentOffset: proposedContentOffset, withScrollingVelocity: velocity)
             return latestOffset
         }


### PR DESCRIPTION
<!-- Thanks for contributing to _VerticalCardSwiper_. Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe how you tested your changes. --->
fixes #37 

### Description
<!--- Describe your changes in detail. -->
Makes cellHeight optional and returns a `Bool` to indicate if scrolling has failed or succeeded.