### PR TITLE
Fix calling `scrollToCard` before the `VerticalCardSwiper` is fully initialised causes a nil crash

### DIFF
--- a/Example/ExampleCardCell.swift
+++ b/Example/ExampleCardCell.swift
@@ -37,7 +37,6 @@ class ExampleCardCell: CardCell {
         let randomRed: CGFloat = CGFloat(arc4random()) / CGFloat(UInt32.max)
         let randomGreen: CGFloat = CGFloat(arc4random()) / CGFloat(UInt32.max)
         let randomBlue: CGFloat = CGFloat(arc4random()) / CGFloat(UInt32.max)
-
         self.backgroundColor = UIColor(red: randomRed, green: randomGreen, blue: randomBlue, alpha: 1.0)
     }
 
@@ -49,7 +48,6 @@ class ExampleCardCell: CardCell {
     override func layoutSubviews() {
 
         self.layer.cornerRadius = 12
-
         super.layoutSubviews()
     }
 }

--- a/Example/ExampleViewController.swift
+++ b/Example/ExampleViewController.swift
@@ -60,7 +60,6 @@ class ExampleViewController: UIViewController, VerticalCardSwiperDelegate, Verti
             contactsDemoData.remove(at: i)
             indexesToRemove.append(i)
         }
-
         cardSwiper.deleteCards(at: indexesToRemove)
     }
 
@@ -81,13 +80,13 @@ class ExampleViewController: UIViewController, VerticalCardSwiperDelegate, Verti
 
     @IBAction func pressScrollUp(_ sender: UIBarButtonItem) {
         if let currentIndex = cardSwiper.focussedIndex {
-            cardSwiper.scrollToCard(at: currentIndex - 1, animated: true)
+            _ = cardSwiper.scrollToCard(at: currentIndex - 1, animated: true)
         }
     }
 
     @IBAction func pressScrollDown(_ sender: UIBarButtonItem) {
         if let currentIndex = cardSwiper.focussedIndex {
-            cardSwiper.scrollToCard(at: currentIndex + 1, animated: true)
+            _ = cardSwiper.scrollToCard(at: currentIndex + 1, animated: true)
         }
     }
 
@@ -96,12 +95,9 @@ class ExampleViewController: UIViewController, VerticalCardSwiperDelegate, Verti
         if let cardCell = verticalCardSwiperView.dequeueReusableCell(withReuseIdentifier: "ExampleCell", for: index) as? ExampleCardCell {
 
             let contact = contactsDemoData[index]
-
             cardCell.setRandomBackgroundColor()
-
             cardCell.nameLbl.text = "Name: " + contact.name
             cardCell.ageLbl.text = "Age: \(contact.age ?? 0)"
-
             return cardCell
         }
         return CardCell()
@@ -117,7 +113,6 @@ class ExampleViewController: UIViewController, VerticalCardSwiperDelegate, Verti
     }
 
     func didSwipeCardAway(card: CardCell, index: Int, swipeDirection: SwipeDirection) {
-
         // called when a card has animated off screen entirely.
     }
 }

--- a/README.md
+++ b/README.md
@@ -86,9 +86,10 @@ class ExampleViewController: UIViewController, VerticalCardSwiperDatasource {
     
     func cardForItemAt(verticalCardSwiperView: VerticalCardSwiperView, cardForItemAt index: Int) -> CardCell {
         
-        let cardCell = verticalCardSwiperView.dequeueReusableCell(withReuseIdentifier: "ExampleCell", for: index) as! ExampleCardCell
-                
-        return cardCell
+        if let cardCell = verticalCardSwiperView.dequeueReusableCell(withReuseIdentifier: "ExampleCell", for: index) as? ExampleCardCell {
+            return cardCell
+        }
+        return CardCell()
     }
     
     func numberOfCards(verticalCardSwiperView: VerticalCardSwiperView) -> Int {
@@ -133,7 +134,7 @@ cardSwiper.focussedIndex
 
 ##### Scroll to a specifc card by calling
 ```swift
-cardSwiper.scrollToCard(at: Int, animated: Bool)
+cardSwiper.scrollToCard(at: Int, animated: Bool) -> Bool
 ```
 
 ##### Moving/Deleting/Inserting cards at runtime

--- a/Sources/VerticalCardSwiper.swift
+++ b/Sources/VerticalCardSwiper.swift
@@ -365,7 +365,8 @@ extension VerticalCardSwiper: UICollectionViewDelegate, UICollectionViewDataSour
      instead of functions like `viewDidLoad` as the underlying collectionView needs to be loaded first for this to work.
      - parameter index: The index of the item to scroll into view.
      - parameter animated: Specify true to animate the scrolling behavior or false to adjust the scroll view’s visible content immediately.
-     - Returns: True if scrolling succeeds. False if scrolling failed because the view layout has not been established yet.
+     - Returns: True if scrolling succeeds. False if scrolling failed.
+     Scrolling could fail due to the flowlayout not being set up yet or an incorrect index.
      */
     public func scrollToCard(at index: Int, animated: Bool) -> Bool {
 
@@ -374,12 +375,15 @@ extension VerticalCardSwiper: UICollectionViewDelegate, UICollectionViewDataSour
          so we're using setContentOffset for the time being.
          See: https://github.com/JoniVR/VerticalCardSwiper/issues/23
          */
-        guard index >= 0, index < verticalCardSwiperView.numberOfItems(inSection: 0), let cellHeight = flowLayout.cellHeight else { return false }
+        guard
+            let cellHeight = flowLayout.cellHeight,
+            index >= 0,
+            index < verticalCardSwiperView.numberOfItems(inSection: 0)
+        else { return false }
 
         let y = CGFloat(index) * (cellHeight + flowLayout.minimumLineSpacing) - topInset
         let point = CGPoint(x: verticalCardSwiperView.contentOffset.x, y: y)
         verticalCardSwiperView.setContentOffset(point, animated: animated)
-        
         return true
     }
 

--- a/Sources/VerticalCardSwiper.swift
+++ b/Sources/VerticalCardSwiper.swift
@@ -365,19 +365,22 @@ extension VerticalCardSwiper: UICollectionViewDelegate, UICollectionViewDataSour
      instead of functions like `viewDidLoad` as the underlying collectionView needs to be loaded first for this to work.
      - parameter index: The index of the item to scroll into view.
      - parameter animated: Specify true to animate the scrolling behavior or false to adjust the scroll view’s visible content immediately.
+     - Returns: True if scrolling succeeds. False if scrolling failed because the view layout has not been established yet.
      */
-    public func scrollToCard(at index: Int, animated: Bool) {
+    public func scrollToCard(at index: Int, animated: Bool) -> Bool {
 
         /**
          scrollToItem & scrollRectToVisible were giving issues with reliable scrolling,
          so we're using setContentOffset for the time being.
          See: https://github.com/JoniVR/VerticalCardSwiper/issues/23
          */
-        guard index >= 0 && index < verticalCardSwiperView.numberOfItems(inSection: 0) else { return }
+        guard index >= 0, index < verticalCardSwiperView.numberOfItems(inSection: 0), let cellHeight = flowLayout.cellHeight else { return false }
 
-        let y = CGFloat(index) * (flowLayout.cellHeight + flowLayout.minimumLineSpacing) - topInset
+        let y = CGFloat(index) * (cellHeight + flowLayout.minimumLineSpacing) - topInset
         let point = CGPoint(x: verticalCardSwiperView.contentOffset.x, y: y)
         verticalCardSwiperView.setContentOffset(point, animated: animated)
+        
+        return true
     }
 
     /**

--- a/Sources/VerticalCardSwiperFlowLayout.swift
+++ b/Sources/VerticalCardSwiperFlowLayout.swift
@@ -30,7 +30,7 @@ internal class VerticalCardSwiperFlowLayout: UICollectionViewFlowLayout {
     /// This property enables paging per card. Default is true.
     internal var isPagingEnabled: Bool = true
     /// Stores the height of a CardCell.
-    internal var cellHeight: CGFloat!
+    internal var cellHeight: CGFloat?
     /// Allows you to make the previous card visible or not visible (stack effect). Default is `true`.
     internal var isPreviousCardVisible: Bool = true
 
@@ -83,7 +83,7 @@ internal class VerticalCardSwiperFlowLayout: UICollectionViewFlowLayout {
     internal override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint, withScrollingVelocity velocity: CGPoint) -> CGPoint {
 
         // If the property `isPagingEnabled` is set to false, we don't enable paging and thus return the current contentoffset.
-        guard let collectionView = self.collectionView, isPagingEnabled else {
+        guard let collectionView = self.collectionView, let cellHeight = cellHeight, isPagingEnabled else {
             let latestOffset = super.targetContentOffset(forProposedContentOffset: proposedContentOffset, withScrollingVelocity: velocity)
             return latestOffset
         }

--- a/Sources/VerticalCardSwiperFlowLayout.swift
+++ b/Sources/VerticalCardSwiperFlowLayout.swift
@@ -82,8 +82,11 @@ internal class VerticalCardSwiperFlowLayout: UICollectionViewFlowLayout {
     // Cell paging
     internal override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint, withScrollingVelocity velocity: CGPoint) -> CGPoint {
 
-        // If the property `isPagingEnabled` is set to false, we don't enable paging and thus return the current contentoffset.
-        guard let collectionView = self.collectionView, let cellHeight = cellHeight, isPagingEnabled else {
+        guard
+            let collectionView = self.collectionView,
+            let cellHeight = cellHeight,
+            isPagingEnabled
+        else {
             let latestOffset = super.targetContentOffset(forProposedContentOffset: proposedContentOffset, withScrollingVelocity: velocity)
             return latestOffset
         }


### PR DESCRIPTION
See #41

Thanks to [@geniegeist](https://github.com/geniegeist)
(I screwed up and did "squash and merge" instead of regular merge on the previous PR so he doesn't get credit automatically 😕)