### PR TITLE
Fix `isStackOnBottom` and `stackedCardsCount` not working on 2.3.0

### DIFF
--- a/Sources/VerticalCardSwiperFlowLayout.swift
+++ b/Sources/VerticalCardSwiperFlowLayout.swift
@@ -187,7 +187,7 @@ internal class VerticalCardSwiperFlowLayout: UICollectionViewFlowLayout {
             var t = CGAffineTransform.identity
 
             let calculatedScale = scale > 0 ? scale : 0
-            t = t.scaledBy(x: calculatedScale, y: calculatedScale)
+            t = t.scaledBy(x: calculatedScale, y: 1)
             if isStackingEnabled {
                 t = t.translatedBy(x: 0, y: top * translationScale)
             }


### PR DESCRIPTION
…2.3.0 #78

<!-- Thanks for contributing to _VerticalCardSwiper_. Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.
- [x] I've added additional Tests where/if it makes sense.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. Use "fixes #2" or "closes #2" -->
<!--- Please describe how you tested your changes. --->

### Description
<!--- Describe your changes in detail. -->
