### PR TITLE
docs: fix wrong type in Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,12 +181,12 @@ class ViewController: UIViewController, VerticalCardSwiperDelegate {
         cardSwiper.delegate = self
     }
     
-    func willSwipeCardAway(card: CardCell, index: Int, swipeDirection: CellSwipeDirection) {
+    func willSwipeCardAway(card: CardCell, index: Int, swipeDirection: SwipeDirection) {
     
         // called right before the card animates off the screen (optional).
     }
 
-    func didSwipeCardAway(card: CardCell, index: Int, swipeDirection: CellSwipeDirection) {
+    func didSwipeCardAway(card: CardCell, index: Int, swipeDirection: SwipeDirection) {
 
         // handle swipe gestures (optional).
     }


### PR DESCRIPTION
Thanks for the amazing job!
I noticed that there could be an error in the README.

When I'm using `CellSwipeDirection` I get:
> Cannot find type 'CellSwipeDirection' in scope

### Checklist
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.